### PR TITLE
Refactor guards for service calls

### DIFF
--- a/lib/notifiex/services/discord.ex
+++ b/lib/notifiex/services/discord.ex
@@ -4,6 +4,8 @@ defmodule Notifiex.Service.Discord do
   """
 
   @behaviour Notifiex.ServiceBehaviour
+  @type payload :: %{required(:content) => binary}
+  @type options :: %{required(:webhook) => binary}
 
   @doc """
   Sends a message through Webhooks.
@@ -14,16 +16,15 @@ defmodule Notifiex.Service.Discord do
   `options` should include the following:
   * `webhook`: Webhook URI. (required)
   """
-  @spec call(map, map) :: {:ok, binary} | {:error, {atom, any}}
-  def call(payload, options) when is_map(payload) and is_map(options) do
-    webhook = Map.get(options, :webhook)
-
+  @spec call(payload(), payload()) :: Notifiex.result()
+  def call(payload = %{"content" => _}, options = %{"webhook" => webhook})
+      when is_map(payload) and is_map(options) do
     send_discord(payload, webhook)
   end
 
-  @spec send_discord(map, binary) :: {:ok, binary} | {:error, {atom, any}}
-  defp send_discord(_payload, nil), do: {:error, {:missing_options, nil}}
+  def call(_, _), do: {:error, {:missing_required_params}, nil}
 
+  @spec send_discord(map, binary) :: Notifiex.result()
   defp send_discord(payload, url) do
     json_payload = Poison.encode!(payload)
 

--- a/lib/notifiex/services/discord.ex
+++ b/lib/notifiex/services/discord.ex
@@ -17,12 +17,16 @@ defmodule Notifiex.Service.Discord do
   * `webhook`: Webhook URI. (required)
   """
   @spec call(payload(), payload()) :: Notifiex.result()
-  def call(payload = %{"content" => _}, options = %{"webhook" => webhook})
-      when is_map(payload) and is_map(options) do
+  def call(payload = _, options = _)
+      when not (is_map(payload) and is_map(options) and is_map_key(payload, :content) and
+                  is_map_key(options, :webhook)),
+      do: {:error, {:missing_required_params}, nil}
+
+  def call(payload, options) do
+    webhook = Map.get(options, :webhook)
+
     send_discord(payload, webhook)
   end
-
-  def call(_, _), do: {:error, {:missing_required_params}, nil}
 
   @spec send_discord(map, binary) :: Notifiex.result()
   defp send_discord(payload, url) do

--- a/lib/notifiex/services/slack.ex
+++ b/lib/notifiex/services/slack.ex
@@ -24,12 +24,14 @@ defmodule Notifiex.Service.Slack do
   * `files`: List of files to be uploaded (optional)
   """
   @spec call(payload(), options()) :: Notifiex.result()
-  def call(payload, options)
+  def call(payload = _, options = _)
+      when not (is_map(payload) and is_map(options) and is_map_key(payload, :text) and
+                  is_map_key(payload, :channel) and is_map_key(options, :token)),
+      do: {:error, {:missing_required_params}, nil}
 
-  def call(payload = %{"text" => _, "channel" => _}, options = %{"token" => token})
-      when is_map(payload) and is_map(options) do
-    IO.puts("text #{Map.get(payload, :text)}")
+  def call(payload, options) do
     url = "https://slack.com/api/chat.postMessage"
+    token = Map.get(options, :token)
 
     # send message (without file)
     result = send_message(payload, url, token)
@@ -49,8 +51,6 @@ defmodule Notifiex.Service.Slack do
       end
     end
   end
-
-  def call(_, _), do: {:error, {:missing_required_params}, nil}
 
   @spec send_message(map, binary, binary) :: Notifiex.result()
   defp send_message(payload, url, token) do

--- a/lib/notifiex/services/slack.ex
+++ b/lib/notifiex/services/slack.ex
@@ -4,6 +4,12 @@ defmodule Notifiex.Service.Slack do
   """
 
   @behaviour Notifiex.ServiceBehaviour
+  @type payload :: %{required(:text) => binary, required(:channel) => binary}
+  @type options :: %{
+          required(:token) => binary,
+          optional(:channel_ids) => any,
+          optional(:files) => any
+        }
 
   @doc """
   Sends a message to the specified channel.
@@ -14,11 +20,16 @@ defmodule Notifiex.Service.Slack do
 
   `options` should include the following:
   * `token`: Authentication token. (required)
+  * `channel_ids`: List of channel IDs for file upload (optional)
+  * `files`: List of files to be uploaded (optional)
   """
-  @spec call(map, map) :: {:ok, binary} | {:error, {atom, any}}
-  def call(payload, options) when is_map(payload) and is_map(options) do
+  @spec call(payload(), options()) :: Notifiex.result()
+  def call(payload, options)
+
+  def call(payload = %{"text" => _, "channel" => _}, options = %{"token" => token})
+      when is_map(payload) and is_map(options) do
+    IO.puts("text #{Map.get(payload, :text)}")
     url = "https://slack.com/api/chat.postMessage"
-    token = Map.get(options, :token)
 
     # send message (without file)
     result = send_message(payload, url, token)
@@ -39,7 +50,9 @@ defmodule Notifiex.Service.Slack do
     end
   end
 
-  @spec send_message(map, binary, binary) :: {:ok, binary} | {:error, {atom, any}}
+  def call(_, _), do: {:error, {:missing_required_params}, nil}
+
+  @spec send_message(map, binary, binary) :: Notifiex.result()
   defp send_message(payload, url, token) do
     json_payload = Poison.encode!(payload)
 
@@ -66,7 +79,7 @@ defmodule Notifiex.Service.Slack do
     end
   end
 
-  @spec send_files(binary, binary, binary) :: {:ok, binary} | {:error, {atom, any}}
+  @spec send_files(binary, binary, binary) :: Notifiex.result()
   defp send_files(files, channels, token) do
     header = [
       {"Authorization", "Bearer " <> token}

--- a/test/notifiex_test.exs
+++ b/test/notifiex_test.exs
@@ -19,4 +19,32 @@ defmodule NotifiexTest do
 
     assert result == {:error, {:mock_error, false}}
   end
+
+  test "Slack notification must not work with missing params" do
+    expected_result = {:error, {:missing_required_params}, nil}
+
+    assert expected_result == Notifiex.send(:slack, nil, nil)
+    assert expected_result == Notifiex.send(:slack, nil, %{})
+    assert expected_result == Notifiex.send(:slack, %{}, nil)
+    assert expected_result == Notifiex.send(:slack, %{}, %{})
+
+    assert expected_result == Notifiex.send(:slack, %{text: "sample", channel: "channel"}, %{})
+    assert expected_result == Notifiex.send(:slack, %{text: "sample"}, %{token: "token"})
+    assert expected_result == Notifiex.send(:slack, %{channel: "channel"}, %{token: "token"})
+    assert expected_result == Notifiex.send(:slack, %{}, %{token: "token"})
+    assert expected_result == Notifiex.send(:slack, %{text: "sample"}, %{})
+    assert expected_result == Notifiex.send(:slack, %{channel: "channel"}, %{})
+  end
+
+  test "Discord notification must not work with missing params" do
+    expected_result = {:error, {:missing_required_params}, nil}
+
+    assert expected_result == Notifiex.send(:discord, nil, nil)
+    assert expected_result == Notifiex.send(:discord, nil, %{})
+    assert expected_result == Notifiex.send(:discord, %{}, nil)
+    assert expected_result == Notifiex.send(:discord, %{}, %{})
+
+    assert expected_result == Notifiex.send(:discord, %{content: "sample"}, %{})
+    assert expected_result == Notifiex.send(:discord, %{}, %{webhook: "webhook"})
+  end
 end


### PR DESCRIPTION
Related to #8 and also fixing #2 :
- In `Notifiex.Services.Slack` add optional parameters to documentation
- Add typespec documentation for `Notifiex.Services.Slack` and `Notifiex.Services.Discord`
- Return `{:error, {:missing_required_params}, nil}` if any required parameters are missing